### PR TITLE
mean function

### DIFF
--- a/pkg/math/Mean.go
+++ b/pkg/math/Mean.go
@@ -1,0 +1,111 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package math
+
+import (
+	stdmath "math"
+	"reflect"
+	"time"
+)
+
+// Mean returns the mean value from the array or slice of ints, floats, or durations.
+// For durations, returns the average duration.
+// For ints and floats, returns a float64.
+func Mean(in interface{}) (interface{}, error) {
+
+	switch in := in.(type) {
+	case []uint8:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := 0
+		for i := 0; i < len(in); i++ {
+			out += int(in[i])
+		}
+		return float64(out) / float64(len(in)), nil
+	case []int:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := 0
+		for i := 0; i < len(in); i++ {
+			out += int(in[i])
+		}
+		return float64(out) / float64(len(in)), nil
+	case []int32:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := 0
+		for i := 0; i < len(in); i++ {
+			out += int(in[i])
+		}
+		return float64(out) / float64(len(in)), nil
+	case []int64:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := int64(0)
+		for i := 0; i < len(in); i++ {
+			out += in[i]
+		}
+		return float64(out) / float64(len(in)), nil
+	case []float64:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := 0.0
+		for i := 0; i < len(in); i++ {
+			out += in[i]
+		}
+		return out / float64(len(in)), nil
+	case []time.Duration:
+		if len(in) == 0 {
+			return nil, ErrEmptyInput
+		}
+		out := int64(0)
+		for i := 0; i < len(in); i++ {
+			out += int64(in[i])
+		}
+		return time.Duration(int64(stdmath.Floor(float64(out) / float64(len(in))))), nil
+	}
+
+	v := reflect.ValueOf(in)
+	t := v.Type()
+	k := t.Kind()
+
+	if k != reflect.Array && k != reflect.Slice {
+		return nil, &ErrInvalidKind{Value: reflect.TypeOf(in), Expected: []reflect.Kind{reflect.Array, reflect.Slice}}
+	}
+
+	if v.Len() == 0 {
+		return nil, ErrEmptyInput
+	}
+
+	sum, err := Sum(in)
+	if err != nil {
+		return nil, err
+	}
+
+	switch sum := sum.(type) {
+	case uint8:
+		return float64(sum) / float64(v.Len()), nil
+	case int32:
+		return float64(sum) / float64(v.Len()), nil
+	case int64:
+		return float64(sum) / float64(v.Len()), nil
+	case int:
+		return float64(sum) / float64(v.Len()), nil
+	case float64:
+		return sum / float64(v.Len()), nil
+	case time.Duration:
+		return time.Duration(int64(stdmath.Floor(float64(int64(sum)) / float64(v.Len())))), nil
+	}
+
+	return nil, &ErrInvalidKind{Value: reflect.TypeOf(sum), Expected: []reflect.Kind{reflect.Array, reflect.Slice}}
+}

--- a/pkg/math/Mean_examples_test.go
+++ b/pkg/math/Mean_examples_test.go
@@ -1,0 +1,62 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package math
+
+import (
+	"fmt"
+	"time"
+)
+
+func ExampleMean_uint8s() {
+	out, err := Mean([]uint8{1, 2, 3})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output: 2
+}
+
+func ExampleMean_ints() {
+	out, err := Mean([]int{10, 20})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output: 15
+}
+
+func ExampleMean_floats() {
+	out, err := Mean([]float64{1.11, 2.22})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output: 1.665
+}
+
+func ExampleMean_durations() {
+	out, err := Mean([]time.Duration{
+		time.Hour * 2,
+		time.Hour * 1,
+		time.Hour * 3,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output: 2h0m0s
+}
+
+func ExampleMean_interface() {
+	out, err := Mean([]interface{}{10, 2.22})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+	// Output: 6.11
+}

--- a/pkg/math/Mean_test.go
+++ b/pkg/math/Mean_test.go
@@ -1,0 +1,90 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package math
+
+import (
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeanUInt8s(t *testing.T) {
+	in := []uint8{2, 4}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(3), out)
+}
+
+func TestMeanInts(t *testing.T) {
+	in := []int{2, 4}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, 3.0, out)
+}
+
+func TestMeanInt32s(t *testing.T) {
+	in := []int32{2, 4}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, 3.0, out)
+}
+
+func TestMeanInt64s(t *testing.T) {
+	in := []int64{2, 4}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, 3.0, out)
+}
+
+func TestMeanFloats(t *testing.T) {
+	in := []float64{1.11, 2.22}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.665, out)
+}
+
+func TestMeanTimes(t *testing.T) {
+	in := []time.Duration{
+		time.Hour * 2,
+		time.Hour * 4,
+	}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Hour*3, out)
+}
+
+func TestMeanInterface(t *testing.T) {
+	in := []interface{}{
+		3,
+		1.5,
+	}
+	out, err := Mean(in)
+	assert.NoError(t, err)
+	assert.Equal(t, 2.25, out)
+}
+
+func TestMeanErrorEmpty(t *testing.T) {
+	in := []interface{}{}
+	out, err := Mean(in)
+	assert.Equal(t, ErrEmptyInput, err)
+	assert.Nil(t, out)
+}
+
+func TestMeanErrorComparison(t *testing.T) {
+	in := []interface{}{
+		2,
+		4,
+		time.Now(),
+	}
+	out, err := Mean(in)
+	assert.IsType(t, &ErrInvalidAddition{}, err)
+	assert.Nil(t, out)
+}


### PR DESCRIPTION
- Delivers https://github.com/spatialcurrent/go-math/issues/3

Adds Mean function.  For `time.Duration`, returns mean duration.  For rest, returns float64.